### PR TITLE
Test 'array of tables' functionality.

### DIFF
--- a/test/spec.coffee
+++ b/test/spec.coffee
@@ -54,6 +54,23 @@ expected =
             'bit#':
                 "what?": "You don't think some user won't do that?"
                 multi_line_array: ["]"]
+    fruit: [
+        {
+            name: 'apple'
+            physical:
+                color: 'red'
+                shape: 'round'
+            variety: [
+                { name: 'red delicious' }
+                { name: 'granny smith' }
+            ]
+        }
+        {
+            name: 'banana'
+            variety:
+                name: 'plantain'
+        }
+    ]
 
 it.only 'should work', ->
 

--- a/test/test.toml
+++ b/test/test.toml
@@ -74,4 +74,22 @@ test_string = "You'll hate me after this - #"          # " Annoying, isn't it?
             "]",
             # ] Oh yes I did
             ]
-            
+
+[[fruit]]
+  name = "apple"
+
+  [fruit.physical]
+    color = "red"
+    shape = "round"
+
+  [[fruit.variety]]
+    name = "red delicious"
+
+  [[fruit.variety]]
+    name = "granny smith"
+
+[[fruit]]
+  name = "banana"
+
+  [[fruit.variety]]
+    name = "plantain"


### PR DESCRIPTION
[Commit 5d991cdf in toml-lang/toml](https://github.com/toml-lang/toml/commit/5d991cdfab3dd8e7011ebf8fa4a0eeb1550101b8) added arrays of tables as a *highly*
useful primitive, but toml.js doesn't seem to support it. Add a test for this functionality in the hope that it will spur further development. :)